### PR TITLE
tap2junit v0.1.5 proposal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,6 @@
+# tap2junit changelog
+
+### 0.1.5
+* Add support for Python 3
+* Add automated testing on Travis CI
+* Remove Pipfile.lock to support multiple Python versions


### PR DESCRIPTION
This will be the first release of __tap2junit__ since its transfer into the Node.js GitHub org nodejs/admin#413.

# tap2junit changelog
### 0.1.5
* Add support for Python 3
* Add automated testing on Travis CI
* Remove Pipfile.lock to support multiple Python versions

To be released at https://pypi.org/project/tap2junit
