### PR TITLE
setup.py: render README.md as markdown on PyPI

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ setuptools.setup(
     version="0.1.5",
     description="Tap13 to jUnit",
     long_description=long_description,
+    long_description_content_type="text/markdown",
     url="https://github.com/nodejs/tap2junit",
     author="Node.js contributors",
     author_email="cclauss@me.com",


### PR DESCRIPTION
https://pypi.org/project/tap2junit/0.1.5/ shows our README.md properly rendered as markdown.  This modification ensures that all future release render on PyPI with the same fidelity.

See: https://packaging.python.org/guides/making-a-pypi-friendly-readme/