### PR TITLE
Update tap13 from upstream, reapply py3 compatibility PR

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setuptools.setup(
     classifiers=[
         "Development Status :: 4 - Beta",
         "Intended Audience :: Developers",
-        "License :: OSI Approved :: GNU General Public License v2 or later (GPLv2+)",
+        "License :: OSI Approved :: Apache License, Version 2.0",
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -14,10 +14,20 @@
 #
 # Author: Josef Skladanka <jskladan@redhat.com>
 
-import re
-import yamlish
-import StringIO
+from __future__ import print_function
 
+import re
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+import yamlish
+
+try:
+    basestring
+except NameError:
+    basestring = str
 
 
 RE_VERSION = re.compile(r"^\s*TAP version 13\s*$")
@@ -133,8 +143,8 @@ class TAP13(object):
 
 
     def parse(self, source):
-        if isinstance(source, (str, unicode)):
-            self._parse(StringIO.StringIO(source))
+        if isinstance(source, basestring):
+            self._parse(StringIO(source))
         elif hasattr(source, "__iter__"):
             self._parse(source)
 
@@ -178,6 +188,6 @@ if __name__ == "__main__":
 
     import pprint
     for test in t.tests:
-        print test.result, test.id, test.description, "#", test.directive, test.comment
+        print(test.result, test.id, test.description, "#", test.directive, test.comment)
         pprint.pprint(test._yaml_buffer)
         pprint.pprint(test.yaml)


### PR DESCRIPTION
```
    Python 3 support

    Floating patch for Python 3 support.
    PR-URL: https://github.com/nodejs/tap2junit/pull/5
```

and
```
    Update tap13.py to latest (Apache licensed)

    Pulled lastest from upstream:

            $ curl -o tap2junit/tap13.py \
                https://bitbucket.org/fedoraqa/pytap13/raw/master/pytap13.py

    Note that the upstream version is now under the Apache License.

    Fixes https://github.com/nodejs/admin/issues/413
```

Fixes https://github.com/nodejs/admin/issues/413