### PR TITLE
WIP: pypistats provides Python version info

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,6 @@ script:
   - python tap2junit/tap13.py
   - python -m tap2junit -i test/fixtures/${FILENAME}.tap -o test/output/${FILENAME}.xml
   - cat test/output/${FILENAME}.xml
-  - pypistats recent schema
-  - pypistats python_major schema --last-month
-  - pypistats python_minor schema --last-month
+  - pypistats recent tap2junit
+  - pypistats python_major tap2junit --last-month
+  - pypistats python_minor tap2junit --last-month

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ env:
   - FILENAME=test
   - FILENAME=test2
   - FILENAME=test3
-install: pip install flake8 junit-xml yamlish
+install: pip install flake8 junit-xml pypistats yamlish
 before_script: flake8 . --max-line-length=88
 script:
   - python tap2junit/tap13.py
   - python -m tap2junit -i test/fixtures/${FILENAME}.tap -o test/output/${FILENAME}.xml
   - cat test/output/${FILENAME}.xml
+  - pypistats recent schema
+  - pypistats python_major schema --last-month
+  - pypistats python_minor schema --last-month


### PR DESCRIPTION
Experimental: Do not merge.

$ `pypistats recent tap2junit`

| last_day | last_month | last_week |
|---------:|-----------:|----------:|
|       39 |        114 |        47 |

$ `pypistats python_major tap2junit --last-month`

| category | percent | downloads |
|----------|--------:|----------:|
| null     |  72.45% |        71 |
| 2        |  18.37% |        18 |
| 3        |   9.18% |         9 |
| Total    |         |        98 |

Date range: 2020-03-01 - 2020-03-31

$ `pypistats python_minor tap2junit --last-month`

| category | percent | downloads |
|----------|--------:|----------:|
| null     |  72.45% |        71 |
| 2.7      |  18.37% |        18 |
| 3.6      |   8.16% |         8 |
| 3.7      |   1.02% |         1 |
| Total    |         |        98 |

Date range: 2020-03-01 - 2020-03-31
