### PR TITLE
Add bail out

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -11,7 +11,7 @@ jobs:
       - run: black --check .
       - run: codespell --quiet-level=2 --skip="*.tap"  # --ignore-words-list="" 
       - run: flake8 . --max-line-length=88 --show-source --statistics
-      - run: isort --check-only --profile black . || true
+      - run: isort -rc --check-only --profile black . || true
       - run: pip install junit_xml yamlish
       - run: mypy --ignore-missing-imports .
       - run: pytest . || true
@@ -19,7 +19,7 @@ jobs:
       - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check
       - run: |
-          for FILENAME in test-eslint1 test-eslint2 test-eslint3 test test2 test3; do
+          for FILENAME in test-eslint1 test-eslint2 test-eslint3 test test2 test3 test-bailout; do
             echo "Testing ${FILENAME}..."
             python tap2junit/tap13.py
             python -m tap2junit -i "test/fixtures/${FILENAME}.tap" -o "test/output/${FILENAME}.xml"

--- a/.gitignore
+++ b/.gitignore
@@ -3,5 +3,7 @@
 # virtualenv
 /.venv
 
+.mypy_cache
+
 dist
 build

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
   - FILENAME=test
   - FILENAME=test2
   - FILENAME=test3
+  - FILENAME=test-bailout
 install: pip install flake8 junit-xml yamlish
 before_script: flake8 . --max-line-length=88
 script:

--- a/tap2junit/__main__.py
+++ b/tap2junit/__main__.py
@@ -26,7 +26,7 @@ def map_yaml_to_junit(test):
             t.add_error_info(error_message, err_output, err_code)
         else:
             t.add_failure_info(error_message, err_output, err_code)
-
+        t.stderr = test.diagnostics
     return t
 
 

--- a/tap2junit/__main__.py
+++ b/tap2junit/__main__.py
@@ -37,11 +37,11 @@ def parse(name, data):
     return TestSuite(name, junit_tests, platform.node())
 
 
-def convert(in_file, out_file):
+def convert(in_file, out_file, pretty=True):
     input_file = os.path.splitext(in_file.name)[0]
     data = in_file.read()
     result = parse(input_file, data)
-    TestSuite.to_file(out_file, [result], prettyprint=True, encoding="utf-8")
+    TestSuite.to_file(out_file, [result], prettyprint=pretty, encoding="utf-8")
 
 
 def main():
@@ -60,8 +60,11 @@ def main():
         help="output file name",
         required=True,
     )
+    arg_parser.add_argument(
+        "--compact", "-c", action="store_true", help="do not prettify the xml output"
+    )
     args = arg_parser.parse_args()
-    convert(args.input, args.output)
+    convert(args.input, args.output, pretty=not args.compact)
 
 
 if __name__ == "__main__":

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -26,7 +26,8 @@ RE_PLAN = re.compile(
 )
 RE_TEST_LINE = re.compile(
     (
-        r"^\s*(?P<result>(not\s+)?ok)\s*(?P<id>\d+)?\s*(?P<description>[^#]+)"
+        r"^\s*(?P<result>(not\s+)?ok|Bail out\!)\s*"
+        r"(?P<id>\d+)?\s*(?P<description>[^#]+)"
         r"?\s*(#\s*(?P<directive>TODO|SKIP)?\s*(?P<comment>.+)?)?\s*$"
     ),
     re.IGNORECASE,
@@ -140,6 +141,12 @@ class TAP13:
                         )
                         self.__tests_counter += 1
                     t = Test(**t_attrs)
+                    if t.result == "Bail out!":
+                        t.result = "not ok"
+                        # according to TAP13 specs, everything after this is an
+                        # explanation of why testing must be stopped
+                        t.diagnostics = t.diagnostics or t.description
+                        t.description = "Bail out for Test %s" % self.__tests_counter
                     self.tests.append(t)
                     in_test = True
                     continue

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -157,9 +157,14 @@ class TAP13:
 
         if len(self.tests) != self.tests_planned:
             for i in range(len(self.tests), self.tests_planned):
-                self.tests.append(
-                    Test("not ok", i + 1, comment="DIAG: Test %s not present")
+                t = Test(
+                    "not ok",
+                    i + 1,
+                    description="Test %s missing" % (i + 1),
+                    comment="DIAG: Test %s not present" % (i + 1),
                 )
+                t.yaml = {"severity": "missing", "exitcode": -1}
+                self.tests.append(t)
 
     def parse(self, source):
         if isinstance(source, str):

--- a/test/fixtures/test-bailout.tap
+++ b/test/fixtures/test-bailout.tap
@@ -1,0 +1,8 @@
+TAP version 13
+1..5
+ok 1 /MyTest/1
+ok 2 /MyTest/2
+# My test 2 comments
+ok 3 /MyTest/3
+Bail out! Fatal condition met which prevent to continue
+


### PR DESCRIPTION
Hello,

this MR principally add the Bail Out! pattern support as defined in https://testanything.org/tap-version-13-specification.html.
I also add an option to make the xml output compact and improve XML generation for tests that have been not found (for example after a Bail Out).

I also added a test file to emphasize the change. For information this test file gives
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites disabled="0" errors="0" failures="2" tests="5" time="0.0">
	<testsuite disabled="0" errors="0" failures="2" name="test-bailout" skipped="0" tests="5" time="0" hostname="SGX-CMP-776">
		<testcase name="/MyTest/1"/>
		<testcase name="/MyTest/2"/>
		<testcase name="/MyTest/3"/>
		<testcase name="None">
			<failure type="failure" message=" (0)"/>
		</testcase>
		<testcase name="None">
			<failure type="failure" message=" (0)"/>
		</testcase>
	</testsuite>
</testsuites>
```
for the master and
```
<?xml version="1.0" encoding="utf-8"?>
<testsuites disabled="0" errors="1" failures="1" tests="5" time="0.0">
	<testsuite disabled="0" errors="1" failures="1" name="test/fixtures/test-bailout" skipped="0" tests="5" time="0" hostname="SGX-CMP-776">
		<testcase name="/MyTest/1"/>
		<testcase name="/MyTest/2"/>
		<testcase name="/MyTest/3"/>
		<testcase name="Bail out for Test 4">
			<failure type="failure" message=" (0)"/>
			<system-err>Fatal condition met which prevent to continue</system-err>
		</testcase>
		<testcase name="Test 5 missing">
			<error type="-1" message="missing (-1)"/>
		</testcase>
	</testsuite>
</testsuites>
```
with this MR