### PR TITLE
Add support for TAP version 12.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-A utility that converts [TAP version 13](https://testanything.org/) to [JUnit](https://junit.org/junit5/). That's it.
+A utility that converts [TAP version 12 and 13](https://testanything.org/) to [JUnit](https://junit.org/junit5/). That's it.
 
 Upstream is currently unmaintained at https://bitbucket.org/fedoraqa/pytap13/src/develop/
 

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -20,7 +20,7 @@ import re
 
 import yamlish
 
-RE_VERSION = re.compile(r"^\s*TAP version 13\s*$")
+RE_VERSION = re.compile(r"^\s*TAP version (?P<version>.*)$")
 RE_PLAN = re.compile(
     r"^\s*(?P<start>\d+)\.\.(?P<end>\d+)\s*(#\s*(?P<explanation>.*))?\s*$"
 )
@@ -68,8 +68,29 @@ class TAP13:
         in_test = False
         in_yaml = False
         in_yaml_block = False
+        version12 = False
+        # see https://testanything.org/tap-version-13-specification.html
+        # To indicate that this is TAP13 the first line must be
+        # 'TAP version 13'
+        non_empty_lines = [
+            line for line in source.getvalue().splitlines() if line.strip()
+        ]
+        match = RE_VERSION.match(non_empty_lines[0])
+        if match:
+            # It is an error if version is anything below 13 (so not an int is an error)
+            version = int(match.groupdict()["version"])
+            if version < 13:
+                raise ValueError("Version specified is less than 13")
+        else:
+            # No version, so it is 12: https://testanything.org/tap-specification.html
+            version12 = True
+            seek_version = False
+            seek_plan = True
+            seek_test = True
+            self.__tests_counter = 0
+
         for line in source:
-            if not seek_version and not in_yaml and RE_VERSION.match(line):
+            if not version12 and not seek_version and RE_VERSION.match(line):
                 # refack: breaking TAP13 spec, to allow multiple TAP headers
                 seek_version = True
                 seek_plan = False
@@ -106,14 +127,19 @@ class TAP13:
                     self.tests[-1].diagnostics.append(line)
                     continue
                 if RE_YAMLISH_START.match(line):
+                    if version12:
+                        raise ValueError(
+                            "Bad TAP format, yaml block detected but no "
+                            "TAP version 13 line"
+                        )
                     self.tests[-1]._yaml_buffer = [line.strip()]
                     in_yaml = True
                     in_yaml_block = False
                     continue
 
-            # this is "beginning" of the parsing, skip all lines until
-            # version is found
-            if seek_version:
+            # this is "beginning" of the parsing for TAP version 13
+            # skip all lines until version is found
+            if not version12 and seek_version:
                 if RE_VERSION.match(line):
                     seek_version = False
                     seek_plan = True
@@ -122,10 +148,10 @@ class TAP13:
                     continue
 
             if seek_plan:
-                m = RE_PLAN.match(line)
-                if m:
-                    d = m.groupdict()
-                    self.tests_planned = int(d.get("end", 0))
+                match = RE_PLAN.match(line)
+                if match:
+                    fields = match.groupdict()
+                    self.tests_planned = int(fields.get("end", 0))
                     seek_plan = False
 
                     # Stop processing if tests were found before the plan
@@ -134,10 +160,10 @@ class TAP13:
                         break
 
             if seek_test:
-                m = RE_TEST_LINE.match(line)
-                if m:
+                match = RE_TEST_LINE.match(line)
+                if match:
                     self.__tests_counter += 1
-                    t_attrs = m.groupdict()
+                    t_attrs = match.groupdict()
                     if t_attrs["id"] is None:
                         t_attrs["id"] = self.__tests_counter
                     t_attrs["id"] = int(t_attrs["id"])
@@ -178,6 +204,8 @@ class TAP13:
                     description="Test %s missing" % (i + 1),
                     comment="DIAG: Test %s not present" % (i + 1),
                 )
+                # Even for version 12 file which doesn't specify YAML we use
+                # this field to ease thing for the caller
                 t.yaml = {"severity": "missing", "exitcode": -1}
                 self.tests.append(t)
 

--- a/test/fixtures/test-plan-at-end.tap
+++ b/test/fixtures/test-plan-at-end.tap
@@ -1,0 +1,8 @@
+TAP version 13
+ok 1 /MyTest/1
+ok 2 /MyTest/2
+# My test 2 comments
+ok 3 /MyTest/3
+not ok 4 /MyTest/3
+ok /MyTest/4
+1..5

--- a/test/fixtures/test-tap12.tap
+++ b/test/fixtures/test-tap12.tap
@@ -1,0 +1,7 @@
+1..5
+ok 1 /MyTest/1
+ok 2 /MyTest/2
+# My test 2 comments
+ok 3 /MyTest/3
+not ok 4 /MyTest/3
+ok /MyTest/4


### PR DESCRIPTION
This is the consequences of two things taken from the TAP specification
document: https://testanything.org/tap-specification.html
  - version line must be the first line and is only required for TAP
version 13, every version explicitly set below 13 is an error.
  - YAML management is only specified for version 13

Add test scenarios for version line missing and test plan at the end
(this is specified that the plan could be at the beginning of output
or at the end)

Signed-off-by: Frederic Martinsons <frederic.martinsons@sigfox.com>