### PR TITLE
Replace bandit, flake8, isort, and pyupgrade with ruff

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -9,14 +9,11 @@ jobs:
         with:
           python-version: 3.x
       - run: pip install --upgrade pip setuptools wheel
-      - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety junit_xml yamlish pytest-clarity
-      - run: bandit --configfile pyproject.toml --recursive .
+      - run: pip install black codespell junit_xml mypy pytest pytest-clarity ruff safety yamlish
+      - run: ruff --format=github .
       - run: black --check .
       - run: codespell --skip="*.tap" --skip "*.xml"  # --ignore-words-list="" 
-      - run: flake8 . --max-complexity=24 --max-line-length=88 --show-source --statistics
-      - run: isort --check-only .
       - run: mypy .
       - run: pytest -vv .
       - run: pytest --doctest-modules .
-      - run: shopt -s globstar && pyupgrade --py36-plus **/*.py
       - run: safety check

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,12 +29,21 @@ tap2junit = "tap2junit.__main__:main"
 [project.urls]
 repository = "https://github.com/nodejs/tap2junit"
 
-[tool.bandit]
-  exclude_dirs = ["test"]
-
-[tool.isort]
-  profile = "black"
-
 [tool.mypy]
-  exclude = ["build/"]
-  ignore_missing_imports = true
+exclude = ["build/"]
+ignore_missing_imports = true
+
+[tool.ruff]
+select = ["A", "B", "C4", "C9", "E", "F", "I", "PL", "S", "UP", "W", "YTT"]
+target-version = "py37"
+
+[tool.ruff.mccabe]
+max-complexity = 24
+
+[tool.ruff.per-file-ignores]
+"test/*" = ["S101"]  # Use of assert detected which is OK in pytests.
+
+[tool.ruff.pylint]
+max-args = 6
+max-branches = 25
+max-statements = 89

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -39,7 +39,9 @@ RE_YAML_BLOCK = re.compile(r"^.*:\s*[|>][+-]?\s*$")
 
 
 class Test:
-    def __init__(self, result, id, description=None, directive=None, comment=None):
+    def __init__(
+        self, result, id, description=None, directive=None, comment=None  # noqa: A002
+    ):
         self.result = result
         self.id = id
         self.description = description
@@ -105,7 +107,7 @@ class TAP13:
         if match:
             # It is an error if version is anything below 13 (so not an int is an error)
             version = int(match.groupdict()["version"])
-            if version < 13:
+            if version < 13:  # noqa: PLR2004
                 raise ValueError("Version specified is less than 13")
         else:
             # No version, so it is 12: https://testanything.org/tap-specification.html
@@ -139,7 +141,7 @@ class TAP13:
                 continue
 
             unstriped_line = line
-            line = unstriped_line.strip()
+            line = unstriped_line.strip()  # noqa: PLW2901
 
             if in_test:
                 if RE_EXPLANATION.match(line):

--- a/test/_common.py
+++ b/test/_common.py
@@ -1,6 +1,6 @@
 import platform
 
-replacements = dict([(platform.node(), "{HOSTNAME}")])
+replacements = {platform.node(): "{HOSTNAME}"}
 
 
 def normalize_output(s):


### PR DESCRIPTION
[Ruff](https://beta.ruff.rs/) supports [over 500 lint rules](https://beta.ruff.rs/docs/rules) including bandit, isort, pylint, pyupgrade, and flake8 plus its plugins, and is written in Rust for speed.

The `ruff` Action uses minimal steps to run in ~10 seconds, rapidly providing intuitive GitHub Annotations to contributors.

![image](https://user-images.githubusercontent.com/3709715/223758136-afc386d2-70aa-4eff-953a-2c2d82ceea23.png)