### PR TITLE
GitHub Action: publish_to_PyPI

### DIFF
--- a/.github/workflows/publish_to_PyPI.yml
+++ b/.github/workflows/publish_to_PyPI.yml
@@ -1,0 +1,27 @@
+
+name: publish_to_PyPI
+on: [push]
+jobs:
+  smoke-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: python -VV
+    # - name: publish_to_PyPI
+    #   if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.PYPI_API_TOKEN }}
+    #     print-hash: true
+    #     verbose: true
+
+    # - name: Publish package to TestPyPI
+    #   uses: pypa/gh-action-pypi-publish@release/v1
+    #   with:
+    #     password: ${{ secrets.TEST_PYPI_API_TOKEN }}
+    #     repository-url: https://test.pypi.org/legacy/
+    #     print-hash: true
+    #     verbose: true


### PR DESCRIPTION
I cannot set the secrets `${{ secrets.PYPI_API_TOKEN }}` and `${{ secrets.TEST_PYPI_API_TOKEN }}` because I do not have access rights to https://github.com/nodejs/tap2junit/settings/secrets/actions .  If I can work with someone who has those access rights, I can provide the two corresponding PyPI tokens for them to enter as GitHub secrets.

Related to:
* #41
* nodejs/node#47048

@nodejs/testing @mhdawson