### PR TITLE
pip install --upgrade pip setuptools wheel

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -8,6 +8,7 @@ jobs:
       - uses: actions/setup-python@v4
         with:
           python-version: 3.x
+      - run: pip install --upgrade pip setuptools wheel
       - run: pip install bandit black codespell flake8 isort mypy pytest pyupgrade safety junit_xml yamlish pytest-clarity
       - run: bandit --configfile pyproject.toml --recursive .
       - run: black --check .


### PR DESCRIPTION
Fixes `safety` error raised as discussed at actions/setup-python#601
```
-> Vulnerability found in setuptools version 65.5.0
   Vulnerability ID: 52495
   Affected spec: <65.5.1
   ADVISORY: Setuptools 65.5.1 includes a fix for CVE-2022-40897: Python
   Packaging Authority (PyPA) setuptools before 65.5.1 allows remote...
   CVE-2022-40897
```
 For more information, please visit https://pyup.io/v/52495/f17