### PR TITLE
chore: fix lint

### DIFF
--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -20,4 +20,3 @@ jobs:
       - run: mypy .
       - run: pytest -vv .
       - run: pytest --doctest-modules .
-      - run: safety check

--- a/.github/workflows/lint_python.yml
+++ b/.github/workflows/lint_python.yml
@@ -15,7 +15,7 @@ jobs:
       - run: pip install --upgrade pip setuptools wheel
       - run: pip install --editable ".[dev]"
       - run: codespell .
-      - run: ruff --output-format=github .
+      - run: ruff check --output-format=github .
       - run: black --check .
       - run: mypy .
       - run: pytest -vv .

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -100,6 +100,9 @@ select = [
     "W",
     "YTT",
 ]
+ignore = [
+  "UP031",
+]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 24 # Recommended: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -99,9 +99,6 @@ select = [
     "W",
     "YTT",
 ]
-ignore = [
-  "UP031",
-]
 
 [tool.ruff.lint.mccabe]
 max-complexity = 24 # Recommended: 10

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,6 @@ dev = [
     "pytest",
     "pytest-clarity",
     "ruff",
-    "safety",
 ]
 
 [project.scripts]

--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -191,16 +191,16 @@ class TAP13:
                         t_attrs["id"] = self.__tests_counter[-1]
                     t_attrs["id"] = int(t_attrs["id"])
                     if t_attrs["id"] < self.__tests_counter[-1]:
-                        raise ValueError("Descending test id on line: %r" % line)
+                        raise ValueError(f"Descending test id on line: {line!r}")
                     # according to TAP13 specs, missing tests must be handled as
                     # 'not ok' so here we add the missing tests in sequence
                     while t_attrs["id"] > self.__tests_counter[-1]:
+                        counter = self.__tests_counter[-1]
                         self.tests.append(
                             Test(
                                 "not ok",
                                 self.__tests_counter[-1],
-                                comment="DIAG: Test %s not present"
-                                % self.__tests_counter[-1],
+                                comment=f"DIAG: Test {counter} not present",
                             )
                         )
                         self.__tests_counter[-1] += 1
@@ -210,9 +210,7 @@ class TAP13:
                         # according to TAP13 specs, everything after this is an
                         # explanation of why testing must be stopped
                         t.diagnostics = t.diagnostics or t.description
-                        t.description = (
-                            "Bail out for Test %s" % self.__tests_counter[-1]
-                        )
+                        t.description = f"Bail out for Test {self.__tests_counter[-1]}"
                     self.tests.append(t)
                     in_test = True
                     continue


### PR DESCRIPTION
prior to this fix:
```
warning: `ruff <path>` is deprecated. Use `ruff check <path>` instead.
Error: tap2junit/tap13.py:194:42: UP031 Use format specifiers instead of percent format
Error: tap2junit/tap[13](https://github.com/nodejs/tap2junit/actions/runs/9361729781/job/25769209475?pr=57#step:7:14).py:202:41: UP031 Use format specifiers instead of percent format
Error: tap2junit/tap13.py:2[14](https://github.com/nodejs/tap2junit/actions/runs/9361729781/job/25769209475?pr=57#step:7:15):29: UP031 Use format specifiers instead of percent format
Error: Process completed with exit code 1.
```