### PR TITLE
Fix XML comparison, compare time within 1e-6 seconds

### DIFF
--- a/test/test_outputs.py
+++ b/test/test_outputs.py
@@ -1,10 +1,53 @@
 import glob
+import math
 import os
 import subprocess
+import xml.etree.ElementTree as ET
 from pathlib import Path
 
 import pytest
 from _common import normalize_output
+
+
+def compare_xml_elements(elem1, elem2):
+    """
+    Recursively assert the equality of two XML elements and their children.
+    """
+    # Compare tags
+    assert elem1.tag == elem2.tag, f"Tag mismatch: {elem1.tag} != {elem2.tag}"
+
+    # Compare text
+    assert (
+        elem1.text == elem2.text
+    ), f"Text mismatch in tag {elem1.tag}: {elem1.text} != {elem2.text}"
+
+    # Compare attributes
+    for attr in elem1.attrib:
+        assert attr in elem2.attrib, f"Attribute '{attr}' missing in tag {elem2.tag}"
+        # 'time' is sensitive to precision
+        if attr == "time":
+            assert math.isclose(
+                float(elem1.attrib[attr]), float(elem2.attrib[attr]), abs_tol=1e-6
+            ), (
+                f"Floating-point mismatch in attribute '{attr}'"
+                f" in tag {elem1.tag}:"
+                f" {elem1.attrib[attr]} != {elem2.attrib[attr]}"
+            )
+        else:
+            assert elem1.attrib[attr] == elem2.attrib[attr], (
+                f"Attribute mismatch in tag {elem1.tag}: {attr}:"
+                f" {elem1.attrib[attr]} != {elem2.attrib[attr]}"
+            )
+
+    # Compare number of children
+    assert len(elem1) == len(elem2), (
+        f"Number of children mismatch in tag {elem1.tag}: "
+        f"{len(elem1)} != {len(elem2)}"
+    )
+
+    # Recursively compare child elements
+    for child1, child2 in zip(elem1, elem2):
+        compare_xml_elements(child1, child2)
 
 
 class TestOutputs:
@@ -17,4 +60,6 @@ class TestOutputs:
         original = f"./test/output/{name}.xml"
         output = f"{tmp_path}/out.xml"
         subprocess.run(["python", "-m", "tap2junit", "-i", file, "-o", output])
-        assert Path(original).read_text() == normalize_output(Path(output).read_text())
+        original_xml = ET.parse(original)
+        output_xml = ET.fromstring(normalize_output(Path(output).read_text()))
+        compare_xml_elements(original_xml.getroot(), output_xml)


### PR DESCRIPTION
There appears to be a difference in how 'time' is generated in the XML output, possibly different in different systems/configurations.

#62 

Possible culprit is how the 'time' attribute is for 'testsuite' elements. https://github.com/kyrus/python-junit-xml/blob/4bd08a272f059998cedf9b7779f944d49eba13a6/junit_xml/__init__.py#L135

Test case attributes appear to be formatted using `'%f' % time`, which is 6 decimal places by default.

For the testsuite, it looks like it's just a `str` call and maybe this is causing different systems to generate time of different precision.

Due to this small differences in how time is encoded in the XML, the test suite may fail due to differences in the amount of precision is encoded on the system.

Add a new function to the test suite that compares the XML document recursively and assert that tags, text and attributes match.

For 'time' attributes, we compare using `math.isclose()` with a tolerance of 1e-6.