### PR TITLE
Bugfix: only pass lefthand whitespace delta to _handle_indentation

### DIFF
--- a/tap2junit/tap13.py
+++ b/tap2junit/tap13.py
@@ -184,7 +184,7 @@ class TAP13:
             if seek_test:
                 match = RE_TEST_LINE.match(line)
                 if match:
-                    self._handle_indentation(len(unstriped_line) - len(line))
+                    self._handle_indentation(len(unstriped_line) - len(unstriped_line.lstrip()))
                     self.__tests_counter[-1] += 1
                     t_attrs = match.groupdict()
                     if t_attrs["id"] is None:


### PR DESCRIPTION
This fixes JUnit output in cases where the TAP file does not end with a trailing newline. It also improves behavior when tests are provided with an empty description which is technically allowed as per the TAP spec.

Take the following input file:
```
1..3
ok 1 Hello, world
ok 2 
ok 3 Hello, world
```

The resulting XML is as follows:

Before:
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites disabled="0" errors="0" failures="2" tests="5" time="0.0">
	<testsuite disabled="0" errors="0" failures="2" name="..." skipped="0" tests="5" time="0" hostname="...">
		<testcase name="Hello, world"/>
		<testcase name="None">
			<failure type="failure" message=" (0)"/>
		</testcase>
		<testcase name="None"/>
		<testcase name="None">
			<failure type="failure" message=" (0)"/>
		</testcase>
		<testcase name="Hello, world"/>
	</testsuite>
</testsuites>
```

After:
```xml
<?xml version="1.0" encoding="utf-8"?>
<testsuites disabled="0" errors="0" failures="0" tests="3" time="0.0">
	<testsuite disabled="0" errors="0" failures="0" name="..." skipped="0" tests="3" time="0" hostname="...">
		<testcase name="Hello, world"/>
		<testcase name="None"/>
		<testcase name="Hello, world"/>
	</testsuite>
</testsuites>
```